### PR TITLE
feat: add basic dashboard app

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,14 @@
+KAFKA_PORT=29092
+KAFKA_CONTROLLER_PORT=29093
+KAFKA_BOOTSTRAP_PORT=9092
+
+FLINK_JOB_MANAGER_PORT=8081
+INFLUXDB_PORT=8086
+
+# The port at which the dashboard is served.
+# Dashboard can be accessed at `http://127.0.0.1:${DASHBOARD_PORT}`
+DASHBOARD_PORT=8050
+
+# The topic from which the dashboard pulls feature values.
+KAFKA_SOURCE_TOPIC=transaction
+KAFKA_FEATURE_TOPIC=user_trans_amt_last_60min

--- a/compose_w_influxdb.yaml
+++ b/compose_w_influxdb.yaml
@@ -52,6 +52,7 @@ services:
     entrypoint: ["/bin/sh", "-c"]
     command: |
       "
+      sleep 2
       # blocks until kafka is reachable
       kafka-topics --bootstrap-server kafka:${KAFKA_PORT} --list
 
@@ -77,12 +78,29 @@ services:
     networks:
       - flink
 
-  dashboard:
-    hostname: dashboard
-    container_name: dashboard
+  influxdb:
+    hostname: influxdb
+    container_name: influxdb
+    image: influxdb:2.3.0
+    ports:
+      - ${INFLUXDB_PORT}:${INFLUXDB_PORT}
+    networks:
+      - flink
+    command: sh -c "influxd & sleep 5; influx config rm dashboard_config && influx setup --name dashboard_config --username dashboard --password dashboard --token dashboard --org dashboard --bucket dashboard --force; sleep infinity"
+    # command: |
+    #   "
+    #   influxd &
+    #   sleep 5
+    #   influx config rm dashboard_config && influx setup --name dashboard_config --username dashboard --password dashboard --token dashboard --org dashboard --bucket dashboard --force
+    #   sleep infinity
+    #   "
+
+  dashboard_w_influxdb:
+    hostname: dashboard_w_influxdb
+    container_name: dashboard_w_influxdb
     ports:
       - ${DASHBOARD_PORT}:${DASHBOARD_PORT}
-    image: dashboard
+    image: dashboard_w_influxdb
     environment:
       KAFKA_SERVICE: kafka
       KAFKA_BOOTSTRAP_PORT: ${KAFKA_PORT}
@@ -92,36 +110,17 @@ services:
       DASHBOARD_PORT: ${DASHBOARD_PORT}
     build:
       context: .
-      dockerfile: dashboard.Dockerfile
+      dockerfile: dashboard_w_influxdb.Dockerfile
       args:
         - DASHBOARD_PORT=${DASHBOARD_PORT}
     depends_on:
       - data-generator
       - init-kafka
+      - influxdb
       - kafka
     networks:
       - flink
-    restart: on-failure:5
-
-  # user-feature-generator:
-  #   image: ibis-flink-feature-generator
-  #   build:
-  #     context: .
-  #     dockerfile: user-feature-generator.Dockerfile
-  #   depends_on:
-  #     - data-generator
-  #   networks:
-  #     - flink
-
-  # category-feature-generator:
-  #   image: ibis-flink-feature-generator
-  #   build:
-  #     context: .
-  #     dockerfile: long-term-category-feature-generator.Dockerfile
-  #   depends_on:
-  #     - data-generator
-  #   networks:
-  #     - flink
+    restart: on-failure
 
 networks:
   flink:

--- a/dashboard.Dockerfile
+++ b/dashboard.Dockerfile
@@ -1,0 +1,22 @@
+FROM python:3.10.13
+
+ARG DASHBOARD_PORT
+
+WORKDIR /app
+
+COPY dashboard .env /app
+
+RUN pip install --upgrade pip
+RUN pip install --no-cache-dir \
+dash \
+gunicorn \
+kafka-python \
+pandas \
+plotly \
+python-dotenv
+
+EXPOSE ${DASHBOARD_PORT}
+
+# Note: Gunicorn redirects the logs to a file by default
+# CMD ["sh", "-c", "gunicorn dashboard:flask_server --bind=0.0.0.0:${DASHBOARD_PORT}"]
+CMD ["python", "-u", "dashboard.py"]

--- a/dashboard/README.md
+++ b/dashboard/README.md
@@ -1,0 +1,88 @@
+# Dashboard: Feature values over time
+
+Basic `dash` app that plots the values for a given set of features over time.
+It displays a separate graph for each feature.
+It reads the feature values from the records pulled from Kafka.
+
+**Note**: File directories in this README start with `/`, which denotes the
+root of the demo repo, e.g., `/dashboard` refers to this folder.
+
+## How to run
+
+As every other service in the demo, dashboard app runs in a container.
+It is defined as `dashboard` in `/compose.yaml`.
+The following command will build the necessary container images and start the `dashboard` app together with the other services:
+```bash
+$ docker-compose up --build
+```
+
+To clean up, the services can be brought down with
+```bash
+$ docker-compose down
+```
+
+## How to configure
+
+Dashboard app takes the configuration information through env (environment) variables.
+Env variables for all services are defined in `/.env`, and passed to the corresponding services in `/compose.yaml`.
+Description for the env variables is given with comments in `/.env`.
+Under normal circumstances, values for the env variables should not be changed.
+
+Graphs displayed on the dashboard are defined and configured in `dashboard/dashboard.py`.
+To learn how to configure the graphs, refer to the global variables defined in `dashboard/dashboard.py` and `dashboard/config.py`, and the inlined comments added for them.
+
+
+## Aligning time windows across the graphs
+
+### Restarting the dashboard
+
+Dashboard is a basic app that pulls records from given Kafka topics, reads the specified feature values, and plots them on separate plots.
+This simplicity is desired to keep the resource requirements of dashboard low enough for a "smooth" run on a laptop.
+However, due to this simplicity, the x-axes between the plots might be misaligned.
+For instance, `user_max_trans_amt_last_60min` is defined as the maximum `amt` in the last `60` mins.
+However, when the plots for `user_max_trans_amt_last_60min` and `amt` are not aligned on the same on the same time window (given in terms of `trans_date_trans_time`),
+it would not be possible to see that `user_max_trans_amt_last_60min` values are indeed the max over past `amt` values.
+
+If the time windows happen to be non-overlapping when you start the dashboard, you can restart the dashboard by following the steps below.
+Restarting the dashboard resets the read pointers to the beginning of the Kafka topics that contains the feature values.
+
+1. Kill the existing dashboard container
+```bash
+$ docker-compose down dashboard
+```
+
+2. Re-create the dashboard container
+```bash
+$ docker-compose down dashboard
+```
+
+3. Visit `http://127.0.0.1:8050/` on your browser and see the plots restarted from the earliest records available in the Kafka topics.
+
+
+### Switch to the dashboard with `InfluxDB`
+
+Aligning the time window acrosss all the graphs requires an intermediate database.
+This option is implemented in `dashboard/dashboard_w_influxdb.py`. As the file name suggests, it relies on an `InfluxDB` instance.
+This intermediate timeseries database enables the dashboard app to
+(1) store the feature values as needed and
+(2) execute time range queries against the database to align multiple plots in their x-axes.
+
+There two downsides of this option:
+- The additional database increases the resource requirement, especially in terms of memory.
+According to our experience on a laptop (M2 Mac), at least 12 GB of memory should be allocated to the Docker environment for a smooth run.
+
+- The app needs to run a query against the database every time the plots are regenerated . Thus the latency of the query is directly reflected on the graph refresh rate.
+This naturally limits the rate in which the plots can progress over the x-axis.
+
+Here are the steps needed to run `dashboard_w_influxdb`:
+1. Start the required docker services including `dashboard_w_influxdb`:
+```bash
+$ docker-compose -f compose_w_influxdb.yaml up
+```
+
+2. Generate the features using one of these options: (1) Run the demo on the notebook, (2) Run the generator with the following command
+```bash
+$ python feature_generation/create_user_features.py --local
+```
+
+4. Visit `http://127.0.0.1:8050/` on your browser and see the graphs.

--- a/dashboard/config.py
+++ b/dashboard/config.py
@@ -1,0 +1,57 @@
+import dotenv
+import os
+
+
+# Default values of env variables are used while running locally.
+ENV_CONFIG = dotenv.dotenv_values(".env")
+DASHBOARD_PORT = int(os.environ.get("DASHBOARD_PORT", default=ENV_CONFIG["DASHBOARD_PORT"]))
+KAFKA_SOURCE_TOPIC = os.environ.get("KAFKA_SOURCE_TOPIC", default=ENV_CONFIG["KAFKA_SOURCE_TOPIC"])
+KAFKA_FEATURE_TOPIC = os.environ.get("KAFKA_FEATURE_TOPIC", default=ENV_CONFIG["KAFKA_FEATURE_TOPIC"])
+KAFKA_SERVICE = os.environ.get("KAFKA_SERVICE", default="localhost")
+KAFKA_BOOTSTRAP_PORT = os.environ.get("KAFKA_BOOTSTRAP_PORT", default=f"{ENV_CONFIG['KAFKA_BOOTSTRAP_PORT']}")
+INFLUXDB_SERVICE = os.environ.get("INFLUXDB_SERVICE", default="localhost")
+INFLUXDB_PORT = os.environ.get("INFLUXDB_PORT", default=f"{ENV_CONFIG['INFLUXDB_PORT']}")
+
+## Plot config
+# List of time series graphs. Each time series is defined by the
+# features (x, y) plotted against each other.
+TOPIC_TO_FIELD_PAIRS_TO_PLOT = {
+    KAFKA_SOURCE_TOPIC: [
+        ("trans_date_trans_time", "amt"),
+        # ("trans_date_trans_time", "cc_num"),
+    ],
+    KAFKA_FEATURE_TOPIC: [
+        ("trans_date_trans_time", "user_max_trans_amt_last_60min"),
+        ("trans_date_trans_time", "user_mean_trans_amt_last_60min"),
+        # ("trans_date_trans_time", "user_trans_count_last_60min"),
+    ]
+}
+
+NUM_ROWS_IN_DASHBOARD = sum(
+    len(field_pairs)
+    for field_pairs in TOPIC_TO_FIELD_PAIRS_TO_PLOT.values()
+)
+print(f"NUM_ROWS_IN_DASHBOARD= {NUM_ROWS_IN_DASHBOARD}")
+DASHBOARD_HEIGHT = 300 * NUM_ROWS_IN_DASHBOARD
+DASHBOARD_WIDTH = 1500
+
+# Max number of (x, y) points plotted on each time series.
+MAX_TIME_SERIES_LENGTH = 100
+print(
+    "Plot config: \n"
+    f"TOPIC_TO_FIELD_PAIRS_TO_PLOT= \n{TOPIC_TO_FIELD_PAIRS_TO_PLOT} \n"
+    f"MAX_TIME_SERIES_LENGTH= {MAX_TIME_SERIES_LENGTH} \n"
+)
+
+
+# Ref: https://developer.mozilla.org/en-US/docs/Web/CSS/named-color
+PLOT_COLOR_LIST = [
+    "blueviolet",
+    "darksalmon",
+    "gold",
+    "darkseagreen",
+    "dodgerblue",
+    "lightseagreen",
+    "black",
+    "orangered"
+]

--- a/dashboard/dashboard.py
+++ b/dashboard/dashboard.py
@@ -1,0 +1,228 @@
+import collections
+import dash
+import kafka
+import json
+import pandas as pd
+import plotly.express as px
+import plotly.graph_objects as go
+import sys
+import threading
+import time
+
+from dash import dcc, html
+from dash.dependencies import Input, Output
+from datetime import datetime
+from plotly import subplots
+
+import config
+
+
+print(
+    "Env variables: \n"
+    f"DASHBOARD_PORT= {config.DASHBOARD_PORT} \n"
+    f"KAFKA_SOURCE_TOPIC= {config.KAFKA_SOURCE_TOPIC} \n"
+    f"KAFKA_FEATURE_TOPIC= {config.KAFKA_FEATURE_TOPIC} \n"
+    f"KAFKA_SERVICE= {config.KAFKA_SERVICE} \n"
+    f"KAFKA_BOOTSTRAP_PORT= {config.KAFKA_BOOTSTRAP_PORT} \n"
+)
+
+## Kafka
+TOPIC_TO_CONSUMER_MAP = {
+    config.KAFKA_SOURCE_TOPIC: None,
+    config.KAFKA_FEATURE_TOPIC: None,
+}
+LOCK = threading.Lock()
+KAFKA_CONSUMERS_READY = False
+
+
+## Dash
+app = dash.Dash(title="Ibis/Flink demo dashboard", update_title=None)
+flask_server = app.server
+
+
+# Plot data
+class TimeSeries:
+    def __init__(
+        self,
+        x_label: str,
+        y_label: str,
+        max_length: int = config.MAX_TIME_SERIES_LENGTH,
+    ):
+        self.x_label = x_label
+        self.y_label = y_label
+
+        self._x_q = collections.deque(maxlen=max_length)
+        self._y_q = collections.deque(maxlen=max_length)
+
+    def append(self, x, y):
+        self._x_q.append(x)
+        self._y_q.append(y)
+
+    def x_list(self):
+        return list(self._x_q)
+
+    def y_list(self):
+        return list(self._y_q)
+
+
+TOPIC_TO_TIMESERIES_LIST = {
+    topic : [
+        TimeSeries(x_label=x, y_label=y)
+        for x, y in field_pairs
+    ]
+    for topic, field_pairs in config.TOPIC_TO_FIELD_PAIRS_TO_PLOT.items()
+}
+
+app.layout = html.Div([
+    html.H1(children="Features Over Time", style={"textAlign": "center"}),
+    html.Br(),
+    html.Div(
+        children=[
+            dcc.Graph(id="real-time-plot"),
+            dcc.Interval(
+                id="interval-component",
+                interval=1 * 200,  # in milliseconds
+                n_intervals=0,
+            )
+        ]
+    ),
+])
+
+
+@app.callback(
+    Output("real-time-plot", "figure"),
+    [Input("interval-component", "n_intervals")]
+)
+def update_plots(n):
+    global TOPIC_TO_CONSUMER_MAP, TOPIC_TO_TIMESERIES_LIST
+
+    # print("update_plots:: started")
+
+    # Do not pull from any topic unless the consumers for all topics
+    # have been constructed. This is to align the x-axes across graphs.
+
+    with LOCK:
+        consumers_ready = KAFKA_CONSUMERS_READY
+
+    if consumers_ready:
+        for topic, consumer in TOPIC_TO_CONSUMER_MAP.items():
+            # print(f"> topic= {topic}")
+
+            data_dict = consumer.poll(1.0, max_records=1)
+            if data_dict:
+                for topic_partition, record_list in data_dict.items():
+                    for record in record_list:
+                        record_as_dict = json.loads(record.value.decode("utf-8"))
+                        # print(f"topic= {topic}, record_as_dict= \n{record_as_dict}")
+
+                        for i, (x_feature, y_feature) in enumerate(config.TOPIC_TO_FIELD_PAIRS_TO_PLOT[topic]):
+                            if topic == config.KAFKA_FEATURE_TOPIC:
+                                x = record_as_dict["after"][x_feature]
+                                y = record_as_dict["after"][y_feature]
+                            else:
+                                x = record_as_dict[x_feature]
+                                y = record_as_dict[y_feature]
+
+                            TOPIC_TO_TIMESERIES_LIST[topic][i].append(x, y)
+
+    figure = subplots.make_subplots(rows=config.NUM_ROWS_IN_DASHBOARD)
+    i = 0
+    for topic, timeseries_list in TOPIC_TO_TIMESERIES_LIST.items():
+        for timeseries in timeseries_list:
+            row = i + 1
+            col = 1
+            figure.add_trace(
+                go.Scatter(
+                    x=timeseries.x_list(),
+                    y=timeseries.y_list(),
+                    mode="lines+markers",
+                    marker=dict(
+                        symbol="square-open",
+                        size=8,
+                        line=dict(width=2),
+                        color=config.PLOT_COLOR_LIST[i]
+                    ),
+                ),
+                row=row,
+                col=col,
+            )
+            figure.update_xaxes(title_text=timeseries.x_label, row=row, col=col)
+            figure.update_yaxes(title_text=timeseries.y_label, row=row, col=col)
+
+            i += 1
+
+    figure.update_layout(height=config.DASHBOARD_HEIGHT, width=config.DASHBOARD_WIDTH)
+    return figure
+
+
+def boot_kafka_consumers():
+    global KAFKA_CONSUMERS_READY, TOPIC_TO_CONSUMER_MAP
+
+    print("boot_kafka_consumers:: started")
+
+    # Create the consumers
+    consumers_created = False
+    while not consumers_created:
+        consumers_created = True
+        for topic, consumer in TOPIC_TO_CONSUMER_MAP.items():
+            if consumer:
+                continue
+
+            try:
+                consumer = kafka.KafkaConsumer(
+                    # topic,
+                    # client_id=topic,
+                    bootstrap_servers=f"{config.KAFKA_SERVICE}:{config.KAFKA_BOOTSTRAP_PORT}",
+                    # group_id="topic",
+                )
+            except kafka.errors.NoBrokersAvailable:
+                print(f"No Kafka broker available for topic= {topic}")
+                consumers_created = False
+                continue
+
+            try:
+                consumer.assign([kafka.TopicPartition(topic, 0)])
+                consumer.seek_to_beginning()
+            except AssertionError:
+                print(f"No partitions are currently assigned for topic= {topic}")
+                consumers_created = False
+                continue
+
+            TOPIC_TO_CONSUMER_MAP[topic] = consumer
+            print(f"Created Kafka consumer for topic= {topic}")
+
+        if not consumers_created:
+            print("boot_kafka_consumers:: Will sleep for 2 sec and try again...")
+            time.sleep(2)
+    print("boot_kafka_consumers:: Created the consumers for all topics.")
+
+    # Wait until each topic is non-empty
+    empty_topic_set = set(TOPIC_TO_CONSUMER_MAP.keys())
+    while empty_topic_set:
+        topic = next(iter(empty_topic_set))
+
+        data_dict = TOPIC_TO_CONSUMER_MAP[topic].poll(1.0, max_records=1)
+        if data_dict:
+            empty_topic_set.remove(topic)
+
+        if empty_topic_set:
+            print("boot_kafka_consumers:: Will sleep for 2 sec and try again...")
+            time.sleep(2)
+    print("boot_kafka_consumers:: All topics are non-empty.")
+
+    with LOCK:
+        KAFKA_CONSUMERS_READY = True
+
+
+if __name__ == "__main__":
+    # boot_kafka_consumers()
+    threading.Thread(target=boot_kafka_consumers, daemon=True).start()
+
+    # Start dash app
+    # app.run_server(host="0.0.0.0", debug=True, port=config.DASHBOARD_PORT, dev_tools_silence_routes_logging=False)
+    app.run_server(host="0.0.0.0", debug=True, port=config.DASHBOARD_PORT)
+
+    # Clean up connections
+    for consumer in TOPIC_TO_CONSUMER_MAP.values():
+        consumer.close()
+    print("Done")

--- a/dashboard/dashboard_w_influxdb.py
+++ b/dashboard/dashboard_w_influxdb.py
@@ -1,0 +1,436 @@
+import collections
+import dash
+import kafka
+import json
+import logging
+import os
+import pandas as pd
+import plotly.express as px
+import plotly.graph_objects as go
+import signal
+import sys
+import threading
+import time
+
+from dash import dcc, html
+from dash.dependencies import Input, Output
+from datetime import datetime, timedelta, timezone
+from dotenv import dotenv_values
+from influxdb_client import InfluxDBClient, Point
+from influxdb_client.client.write_api import SYNCHRONOUS
+from plotly import subplots
+
+import config
+
+
+print(
+    "Env variables: \n"
+    f"DASHBOARD_PORT= {config.DASHBOARD_PORT} \n"
+    f"KAFKA_SOURCE_TOPIC= {config.KAFKA_SOURCE_TOPIC} \n"
+    f"KAFKA_FEATURE_TOPIC= {config.KAFKA_FEATURE_TOPIC} \n"
+    f"KAFKA_SERVICE= {config.KAFKA_SERVICE} \n"
+    f"KAFKA_BOOTSTRAP_PORT= {config.KAFKA_BOOTSTRAP_PORT} \n"
+    f"INFLUXDB_SERVICE= {config.INFLUXDB_SERVICE} \n"
+    f"INFLUXDB_PORT= {config.INFLUXDB_PORT} \n"
+)
+
+## Kafka
+TOPIC_TO_CONSUMER_MAP = {
+    config.KAFKA_SOURCE_TOPIC: None,
+    config.KAFKA_FEATURE_TOPIC: None,
+}
+LOCK = threading.Lock()
+# CONDITION = threading.Condition(lock=LOCK)
+CONDITION = threading.Condition()
+KAFKA_CONSUMERS_READY = False
+
+## Dash
+app = dash.Dash(title="Ibis/Flink demo dashboard", update_title=None)
+flask_server = app.server
+
+# The topic that will determine the x-axis for all graphs.
+# Ther rest of the topics are treated as followers of the leader.
+# Plots for the follower topics will have the same x-axis as
+# the leader topic for every x-field. All follower x-topics must
+# be managed by the leader topic.
+LEADER_KAFKA_TOPIC = config.KAFKA_FEATURE_TOPIC
+print(f"LEADER_KAFKA_TOPIC= {LEADER_KAFKA_TOPIC}")
+
+
+class TopicManager:
+    def __init__(
+        self,
+        topic: str,
+        field_pairs: list[tuple[str, str]],
+    ):
+        self.topic = topic
+        self.field_pairs = field_pairs
+
+        self.field_set = set()
+        for x, y in field_pairs:
+            self.field_set.add(x)
+            self.field_set.add(y)
+
+
+class LeaderTopicManager(TopicManager):
+    def __init__(
+        self,
+        topic: str,
+        field_pairs: list[tuple[str, str]],
+        max_length: int = config.MAX_TIME_SERIES_LENGTH,
+    ):
+        super().__init__(topic=topic, field_pairs=field_pairs)
+
+        self.field_to_queue = {
+            field: collections.deque(maxlen=max_length)
+            for field in self.field_set
+        }
+
+    def append(self, field: str, value):
+        self.field_to_queue[field].append(value)
+
+    def get_x_y_values(self, x_field: str, y_field: str) -> tuple[list, list]:
+        return (
+            list(self.field_to_queue[x_field]),
+            list(self.field_to_queue[y_field]),
+        )
+
+class FollowerTopicManager(TopicManager):
+    def __init__(
+        self,
+        topic: str,
+        field_pairs: list[tuple[str, str]],
+        leader_topic_manager: LeaderTopicManager,
+    ):
+        super().__init__(topic=topic, field_pairs=field_pairs)
+        self.leader_topic_manager = leader_topic_manager
+
+        for x_field, _ in field_pairs:
+            if x_field not in leader_topic_manager.field_set:
+                raise ValueError(
+                    f"Follower topic manager requires `x_field` {x_field} "
+                    "which is not managed by the leader topic manager."
+                )
+
+    def append(self, x_field: str, y_field: str, x_value, y_value):
+        point = (
+            Point("measurement_name")
+            .time(x_value)
+            .tag("topic", self.topic)
+            .tag("x_field", x_field)
+            .tag("y_field", y_field)
+            .field("y_value", float(y_value))
+        )
+        DB_WRITE_API.write(bucket=DB_BUCKET, record=point)
+
+    def get_x_y_values(self, x_field: str, y_field: str) -> tuple[list, list]:
+        # TODO: This might lead to querying db multiple times for the same x-axis,
+        # which is redundant. Leaving it this way for simplicity.
+
+        leader_x_q = self.leader_topic_manager.field_to_queue[x_field]
+        if len(leader_x_q) == 0:
+            return [], []
+
+        x_min = leader_x_q[0]
+        x_min = get_datetime_from_str(x_min).isoformat() + "Z"
+        x_max = leader_x_q[-1]
+        x_max = get_datetime_from_str(x_max).isoformat() + "Z"
+        # x_max = (get_datetime_from_str(x_max) + timedelta(hours=1)).isoformat() + "Z"
+        # print(f"x_field= {x_field}, y_field= {y_field}")
+        # print(f"x_min= {x_min}, x_max= {x_max}")
+        if x_max == x_min:
+            return [], []
+
+        # |> range(start: -1h)'
+        # |> range(start: 2021-05-22T23:30:00Z, stop: 2021-05-23T00:00:00Z)'
+        query = f'from(bucket:"{DB_BUCKET}")\
+        |> range(start: {x_min}, stop: {x_max})\
+        |> filter(fn:(r) => r.topic == "{self.topic}")\
+        |> filter(fn:(r) => r.x_field == "{x_field}")\
+        |> filter(fn:(r) => r.y_field == "{y_field}")'
+        # print(f"query= {query}")
+        tables = DB_QUERY_API.query(query)
+        if not tables:
+            # print(f"`tables` is empty")
+            return [], []
+
+        # print(f"num_results= {len(tables[0].records)}")
+        x_values, y_values = [], []
+        for row in tables[0].records:
+            x_values.append(row["_time"])
+            y_values.append(row["_value"])
+
+        return x_values, y_values
+
+
+class FollowerTopicManagerPool:
+    def __init__(self, leader_topic_manager: LeaderTopicManager):
+        self.leader_topic_manager = leader_topic_manager
+
+        self.topic_to_manager_map = {}
+
+    def add(self, topic: str, field_pairs: list[tuple[str, str]]):
+        self.topic_to_manager_map[topic] = FollowerTopicManager(
+            topic=topic,
+            field_pairs=field_pairs,
+            leader_topic_manager=self.leader_topic_manager,
+        )
+
+    def append(self, topic: str, x_field: str, y_field: str, x_value: str, y_value):
+        # dt = get_datetime_from_str(x_value)
+        # dt = datetime_from_iso8601(x_value)
+        self.topic_to_manager_map[topic].append(
+            x_field=x_field, y_field=y_field, x_value=x_value, y_value=y_value
+        )
+
+    def get_x_y_values(self, topic: str, x_field: str, y_field: str) -> tuple[list, list]:
+        return self.topic_to_manager_map[topic].get_x_y_values(x_field, y_field)
+
+
+def get_datetime_from_str(s: str):
+    return datetime.strptime(s, "%Y-%m-%d %H:%M:%S")
+
+
+def datetime_from_iso8601(iso8601_str):
+    if iso8601_str[-1].upper() == "Z":
+        iso8601_str = f"{iso8601_str[:-1]}+00:00"
+
+    dt = datetime.fromisoformat(iso8601_str)
+
+    if dt.tzinfo is None:
+        dt = dt.replace(tzinfo=timezone.utc)
+
+    return dt
+
+
+DB_BUCKET = "dashboard"
+DB_ORG = "dashboard"
+DB_TOKEN = "dashboard"
+DB_CLIENT = InfluxDBClient(url=f"http://{config.INFLUXDB_SERVICE}:{config.INFLUXDB_PORT}", token=DB_TOKEN, org=DB_ORG)
+DB_WRITE_API = DB_CLIENT.write_api(write_options=SYNCHRONOUS)
+DB_QUERY_API = DB_CLIENT.query_api()
+print("InfluxDBClient is ready.")
+
+# Init managers for leader and follower topics.
+LEADER_TOPIC_MANAGER = LeaderTopicManager(
+    topic=LEADER_KAFKA_TOPIC,
+    field_pairs=config.TOPIC_TO_FIELD_PAIRS_TO_PLOT[LEADER_KAFKA_TOPIC],
+)
+
+FOLLOWER_TOPIC_MANAGER_POOL = FollowerTopicManagerPool(
+    leader_topic_manager=LEADER_TOPIC_MANAGER,
+)
+for topic, field_pairs in config.TOPIC_TO_FIELD_PAIRS_TO_PLOT.items():
+    if topic != LEADER_KAFKA_TOPIC:
+        FOLLOWER_TOPIC_MANAGER_POOL.add(topic, field_pairs)
+
+
+app.layout = html.Div([
+    html.H1(children="Features Over Time", style={"textAlign": "center"}),
+    html.Br(),
+    html.Div(
+        children=[
+            dcc.Graph(id="real-time-plot"),
+            dcc.Interval(
+                id="interval-component",
+                # interval=1 * 100,  # in milliseconds
+                # interval=1 * 200,  # in milliseconds
+                interval=1 * 300,  # in milliseconds
+                # interval=1 * 1000,  # in milliseconds
+                # interval=1 * 10000000,  # in milliseconds
+                n_intervals=0,
+            )
+        ]
+    ),
+])
+
+
+@app.callback(
+    Output("real-time-plot", "figure"),
+    [Input("interval-component", "n_intervals")]
+)
+def update_plots(n):
+    global FOLLOWER_TOPIC_MANAGER_POOL, KAFKA_CONSUMERS_READY, LEADER_TOPIC_MANAGER, TOPIC_TO_CONSUMER_MAP
+
+    with LOCK:
+        consumers_ready = KAFKA_CONSUMERS_READY
+
+    # Pull from leader topic
+    if consumers_ready:
+        consumer = TOPIC_TO_CONSUMER_MAP[LEADER_KAFKA_TOPIC]
+        data_dict = consumer.poll(1.0, max_records=1)
+        # print(f"update_plots:: pulled from topic= {LEADER_KAFKA_TOPIC}")
+        if data_dict:
+            for topic_partition, record_list in data_dict.items():
+                for record in record_list:
+                    record_as_dict = json.loads(record.value.decode("utf-8"))
+                    # print(f"record_as_dict= \n{record_as_dict}")
+
+                    for i, field in enumerate(LEADER_TOPIC_MANAGER.field_set):
+                        if LEADER_KAFKA_TOPIC == config.KAFKA_FEATURE_TOPIC:
+                            value = record_as_dict["after"][field]
+                        else:
+                            value = record_as_dict[field]
+
+                        LEADER_TOPIC_MANAGER.append(field=field, value=value)
+
+    # Construct the graphs
+    figure = subplots.make_subplots(rows=config.NUM_ROWS_IN_DASHBOARD)
+    i = 0
+    for topic, field_pairs in config.TOPIC_TO_FIELD_PAIRS_TO_PLOT.items():
+        # print(f"> topic= {topic}")
+
+        for x_field, y_field in field_pairs:
+            row = i + 1
+            col = 1
+
+            if topic == LEADER_KAFKA_TOPIC:
+                x_values, y_values = LEADER_TOPIC_MANAGER.get_x_y_values(
+                    x_field=x_field, y_field=y_field
+                )
+            else:
+                x_values, y_values = FOLLOWER_TOPIC_MANAGER_POOL.get_x_y_values(
+                    topic=topic, x_field=x_field, y_field=y_field
+                )
+
+            figure.add_trace(
+                go.Scatter(
+                    x=x_values,
+                    y=y_values,
+                    mode="lines+markers",
+                    marker=dict(
+                        symbol="square-open",
+                        size=8,
+                        line=dict(width=2),
+                        color=config.PLOT_COLOR_LIST[i]
+                    ),
+                ),
+                row=row,
+                col=col,
+            )
+            figure.update_xaxes(title_text=x_field, row=row, col=col)
+            figure.update_yaxes(title_text=y_field, row=row, col=col)
+
+            i += 1
+
+    figure.update_layout(height=config.DASHBOARD_HEIGHT, width=config.DASHBOARD_WIDTH)
+    return figure
+
+
+def boot_kafka_consumers():
+    global CONDITION, KAFKA_CONSUMERS_READY, TOPIC_TO_CONSUMER_MAP
+
+    print("boot_kafka_consumers:: started")
+
+    # Create the consumers
+    consumers_created = False
+    while not consumers_created:
+        consumers_created = True
+        for topic, consumer in TOPIC_TO_CONSUMER_MAP.items():
+            if consumer:
+                continue
+
+            try:
+                consumer = kafka.KafkaConsumer(
+                    # topic,
+                    # client_id=topic,
+                    bootstrap_servers=f"{config.KAFKA_SERVICE}:{config.KAFKA_BOOTSTRAP_PORT}",
+                    # group_id="topic",
+                )
+            except kafka.errors.NoBrokersAvailable:
+                print(f"boot_kafka_consumers:: No Kafka broker available for topic= {topic}")
+                consumers_created = False
+                continue
+
+            try:
+                consumer.assign([kafka.TopicPartition(topic, 0)])
+                consumer.seek_to_beginning()
+            except AssertionError:
+                print(f"boot_kafka_consumers:: No partitions are currently assigned for topic= {topic}")
+                consumers_created = False
+                continue
+
+            TOPIC_TO_CONSUMER_MAP[topic] = consumer
+            print(f"boot_kafka_consumers:: Created Kafka consumer for topic= {topic}")
+
+        if not consumers_created:
+            print("boot_kafka_consumers:: Will sleep for 2 sec and try again...")
+            time.sleep(2)
+    print("boot_kafka_consumers:: Created the consumers for all topics.")
+
+    with LOCK:
+        KAFKA_CONSUMERS_READY = True
+    with CONDITION:
+        CONDITION.notify_all()
+
+
+def consume_from_follower_topics(follower_topic_manager_pool: FollowerTopicManagerPool):
+    global CONDITION, KAFKA_CONSUMERS_READY
+
+    print("consume_from_follower_topics:: Will wait for Kafka consumers...")
+    with CONDITION:
+        CONDITION.wait_for(lambda: KAFKA_CONSUMERS_READY)
+    print("consume_from_follower_topics:: Kafka consumers are ready.")
+
+    while True:
+        time.sleep(0.001)
+        for topic, consumer in TOPIC_TO_CONSUMER_MAP.items():
+            if topic == LEADER_KAFKA_TOPIC:
+                continue
+
+            consumer = TOPIC_TO_CONSUMER_MAP[topic]
+
+            data_dict = consumer.poll(1.0, max_records=1)
+            # print(f"Pulled from topic= {topic}")
+            if not data_dict:
+                continue
+
+            for topic_partition, record_list in data_dict.items():
+                for record in record_list:
+                    record_as_dict = json.loads(record.value.decode("utf-8"))
+                    # print(f"topic= {topic}, record_as_dict= \n{record_as_dict}")
+
+                    for i, (x_field, y_field) in enumerate(config.TOPIC_TO_FIELD_PAIRS_TO_PLOT[topic]):
+                        if topic == config.KAFKA_FEATURE_TOPIC:
+                            x_value = record_as_dict["after"][x_field]
+                            y_value = record_as_dict["after"][y_field]
+                        else:
+                            x_value = record_as_dict[x_field]
+                            y_value = record_as_dict[y_field]
+
+                        follower_topic_manager_pool.append(
+                            topic=topic, x_field=x_field, y_field=y_field, x_value=x_value, y_value=y_value
+                        )
+
+    print("consume_from_follower_topics:: done")
+
+
+if __name__ == "__main__":
+    # Clear DB
+    start = "1970-01-01T00:00:00Z"
+    stop = "2025-01-01T00:00:00Z"
+    delete_api = DB_CLIENT.delete_api()
+    print(f"Clearing InfluxDB bucket {DB_BUCKET}...")
+    delete_api.delete(start, stop, predicate="", bucket=DB_BUCKET, org=DB_ORG)
+    print(f"Cleared InfluxDB bucket {DB_BUCKET}")
+
+    # Start `boot_kafka_consumers`
+    threading.Thread(target=boot_kafka_consumers, daemon=True).start()
+
+    # Start `consume_from_follower_topics`
+    threading.Thread(
+        target=consume_from_follower_topics,
+        args=[FOLLOWER_TOPIC_MANAGER_POOL],
+        daemon=True,
+    ).start()
+
+    # Start app
+    app.run_server(host="0.0.0.0", debug=True, port=config.DASHBOARD_PORT, dev_tools_silence_routes_logging=False)
+    # app.run_server(host="0.0.0.0", debug=True, port=config.DASHBOARD_PORT)
+
+    # Clean up connections
+    for consumer in TOPIC_TO_CONSUMER_MAP.values():
+        consumer.close()
+
+    DB_CLIENT.close()
+    print("Done")

--- a/dashboard_w_influxdb.Dockerfile
+++ b/dashboard_w_influxdb.Dockerfile
@@ -1,0 +1,23 @@
+FROM python:3.10.13
+
+ARG DASHBOARD_PORT
+
+WORKDIR /app
+
+COPY dashboard .env /app
+
+RUN pip install --upgrade pip
+RUN pip install --no-cache-dir \
+dash \
+gunicorn \
+kafka-python \
+pandas \
+plotly \
+python-dotenv \
+influxdb-client
+
+EXPOSE ${DASHBOARD_PORT}
+
+# Note: Gunicorn redirects the logs to a file by default
+# CMD ["sh", "-c", "gunicorn dashboard_w_influxdb:flask_server --bind=0.0.0.0:${DASHBOARD_PORT}"]
+CMD ["python", "-u", "dashboard_w_influxdb.py"]

--- a/generate_source_data.py
+++ b/generate_source_data.py
@@ -12,7 +12,6 @@ from kafka import KafkaProducer, errors
 
 
 def write_fraud_detection_data_from_s3(producer):
-
     topic = "transaction"
     batch_size = 1000
 
@@ -41,6 +40,7 @@ def write_fraud_detection_data_from_s3(producer):
     keys = next(reader)
 
     print(f"Send records to Kafka topic {topic}")
+    num_batches = 0
     cnt = 0
     for values in reader:
         data_dict = dict(zip(keys, values))
@@ -61,7 +61,12 @@ def write_fraud_detection_data_from_s3(producer):
             producer.flush()
             print(f"send {cnt} rows to kafka")
             cnt = 0
+            num_batches += 1
             sleep(1)
+
+        if num_batches > 100:
+            break
+
     if cnt > 0:
         producer.flush()
     producer.close()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,6 @@
 apache-flink==1.18.0
+dash
 ibis-framework @ git+https://github.com/ibis-project/ibis.git@main
 kafka-python
+plotly
+python-dotenv

--- a/run.sh
+++ b/run.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+
+# Utility script for running individual demo components.
+# Meant to be used ONLY for debugging purposes.
+
+if [ $1 = "dl" ]; then
+  # python3 dashboard/dashboard.py
+  python3 dashboard/dashboard_w_influxdb.py
+
+elif [ $1 = "dd" ]; then
+  docker-compose up dashboard --build
+
+elif [ $1 = "diu" ]; then
+  # docker-compose -f compose_w_influxdb.yaml up dashboard_w_influxdb --build
+  docker-compose -f compose_w_influxdb.yaml up --build
+
+elif [ $1 = "did" ]; then
+  docker-compose -f compose_w_influxdb.yaml down
+
+elif [ $1 = "ci" ]; then
+  docker exec -it influxdb sleep 2 && influx config rm dashboard_config && influx setup --name dashboard_config --username dashboard --password dashboard --token dashboard --org dashboard --bucket dashboard --force
+
+elif [ $1 = "f" ]; then
+  python feature_generation/create_user_features.py --local
+
+elif [ $1 = "s" ]; then
+  influx config rm dashboard_config
+  influx setup \
+	 --name dashboard_config \
+	 --username dashboard \
+	 --password dashboard \
+	 --token dashboard \
+	 --org dashboard \
+	 --bucket dashboard \
+	 --force
+
+else
+  echo "Unexpected arg= $1"
+fi


### PR DESCRIPTION
Adds the boilerplate code for a `dash` app to pull records from a given Kafka topic and plot feature values over time. Also contains refinements around `compose.yaml`. See `dashboard/README.md` (included in this change) for further information on the dashboard.

Here is a snapshot of the dashboard:

<img width="1196" alt="image" src="https://github.com/claypotai/ibis-flink-example/assets/3505416/45cca15b-9fb0-4190-9b61-b1550bf92b82">

**Note to reviewers**: Please pay attention to the following:
* This introduces the first iteration for the dashboard. Modifications can be done as a follow-up:
  * Use a different viz framework other than `dash`.
  * Add/remove/modify the graphs on the dashboard.
  * Prettify the graphs.
* While looking at `dashboard_w_influxdb`, note that Grafana supports InfluxDB, so we can add Grafana into the picture if we want more sophisticated dashboard capabilities. However, as noted in the README, InfluxDB already increases the resource requirement which reduces the convenience of running the demo on a laptop. Grafana would only make this worse.
